### PR TITLE
remove obsolete hack for autoloading custom fish functions

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -9,10 +9,6 @@ end
 # add custom executables (e.g. git-shalector and subl) to path
 set --prepend PATH "$HOME/bin"
 
-# ensure the functions in this repo are available by prepending the functions directory
-# path to fish_function_path
-set --prepend fish_function_path $dotfile_fish_functions_path
-
 set -xg EDITOR "nvim"
 # set some sensible default options to always pass into invocations of less
 set -xg LESS "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"


### PR DESCRIPTION
This is a remnant from #6 that I missed. I was using
```
# make the path to this repo's fish functions universally available so that config.fish can
# prepend it to fish_function_path
set -U dotfile_fish_functions_path "$repo_root/fish/functions"
```
from https://github.com/patrickf3139/dotfiles/blob/c4d30021f970e768459a6ff7777cd49a1bb81996/symlink_configs.fish
and `set --prepend fish_function_path $dotfile_fish_functions_path` in `config.fish` to make sure my custom fish functions would be autoloaded. But now that my custom fish functions are git checkout'ed directly into the `.config/fish/functions` directory, this is no longer needed.