### PR TITLE
Make VSCode key bindings mnemonic

### DIFF
--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -3,7 +3,7 @@
 // 2. unbind target key(s)
 // 3. bind target key(s)
 [
-    // change goto line to cmd+l
+    // change gotoLine to cmd+l
     {
         "key": "ctrl+g",
         "command": "-workbench.action.gotoLine"
@@ -25,7 +25,7 @@
         "when": "editorTextFocus && vim.active && !inDebugRepl"
     },
 
-    // change trigger suggest to alt+space
+    // change triggerSuggest to alt+space
     {
         "key": "ctrl+space",
         "command": "-editor.action.triggerSuggest",
@@ -93,7 +93,7 @@
         "when": "editorTextFocus && !editorReadonly"
     },
 
-    // change go to references to cmd+r
+    // change goToReferences to cmd+r
     {
         "key": "cmd+r",
         "command": "-workbench.action.reloadWindow",
@@ -110,7 +110,7 @@
         "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
     },
 
-    // change go to implementation to cmd+i
+    // change goToImplementation to cmd+i
     {
         "key": "cmd+f12",
         "command": "-editor.action.goToImplementation",
@@ -118,6 +118,95 @@
     },
     {
         "key": "cmd+i",
-        "command": "editor.action.goToImplementation"
+        "command": "references-view.findImplementations"
     },
+
+    // change showAllSymbols symbols to shift+cmd+s
+    {
+        "key": "cmd+t",
+        "command": "-workbench.action.showAllSymbols"
+    },
+    {
+        "key": "shift+cmd+s",
+        "command": "-workbench.action.files.saveAs"
+    },
+    {
+        "key": "shift+cmd+s",
+        "command": "workbench.action.showAllSymbols"
+    },
+
+    // change gotoSymbol to ctrl+g
+    {
+        "key": "shift+cmd+o",
+        "command": "-workbench.action.gotoSymbol"
+    },
+    {
+        "key": "ctrl+g", // already unbinded in gotoLine section
+        "command": "workbench.action.gotoSymbol"
+    },
+
+    // change showCommands to shift+cmd+p
+    {
+        "key": "shift+cmd+p",
+        "command": "-workbench.action.showCommands"
+    },
+    {
+        "key": "shift+cmd+c",
+        "command": "-workbench.action.terminal.openNativeConsole",
+        "when": "!terminalFocus"
+    },
+    {
+        "key": "shift+cmd+c",
+        "command": "workbench.action.showCommands"
+    },
+
+    // change quickOpen to shift+cmd+o
+    {
+        "key": "cmd+p",
+        "command": "-workbench.action.quickOpen"
+    },
+    {
+        "key": "shift+cmd+o", // already unbinded in gotoSymbol section
+        "command": "workbench.action.quickOpen"
+    },
+
+    // change rename to shift+cmd+r
+    {
+        "key": "f2",
+        "command": "-editor.action.rename",
+        "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "shift+cmd+r",
+        "command": "-rerunSearchEditorSearch",
+        "when": "inSearchEditor"
+    },
+    {
+        "key": "shift+cmd+r",
+        "command": "-solargraph.search"
+    },
+    {
+        "key": "shift+cmd+r",
+        "command": "editor.action.rename",
+        "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+p",
+        "command": "-workbench.action.quickOpenNavigateNextInFilePicker",
+        "when": "inFilesPicker && inQuickOpen"
+    },
+
+    // change triggerParameterHints to cmd+p
+    {
+        "key": "cmd+p", // already unbinded in quickOpen section
+        "command": "editor.action.triggerParameterHints",
+        "when": "editorHasSignatureHelpProvider && editorTextFocus"
+    },
+    {
+        "key": "shift+cmd+space",
+        "command": "-editor.action.triggerParameterHints",
+        "when": "editorHasSignatureHelpProvider && editorTextFocus"
+    },
+
+
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -1,5 +1,7 @@
-// Place your key bindings in this file to override the defaults
-// order of each section key bindings: (1) existing keys to unbind (2) target keys to unbind (3) bind target keys
+// Order of each section's key bindings:
+// 1. undo default bindings for action(s)
+// 2. unbind target key(s)
+// 3. bind target key(s)
 [
     // change goto line to cmd+l
     {
@@ -89,5 +91,22 @@
         "key": "shift+alt+down",
         "command": "-editor.action.copyLinesDownAction",
         "when": "editorTextFocus && !editorReadonly"
+    },
+
+    // change go to references to cmd+r
+    {
+        "key": "cmd+r",
+        "command": "-workbench.action.reloadWindow",
+        "when": "isDevelopment"
+    },
+    {
+        "key": "shift+f12",
+        "command": "-editor.action.goToReferences",
+        "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+    },
+    {
+        "key": "cmd+r",
+        "command": "editor.action.goToReferences",
+        "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
     },
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -75,7 +75,7 @@
         "command": "workbench.action.previousEditor"
     },
 
-    // change navigating to ctrl+[ and ctrl+]
+    // change navigation to ctrl+[ and ctrl+]
     {
         "key": "ctrl+shift+-",
         "command": "-workbench.action.navigateForward"

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -157,7 +157,7 @@
         "command": "workbench.action.showAllSymbols"
     },
 
-    // change gotoSymbol to ctrl+g
+    // change gotoSymbol to alt+g
     {
         "key": "shift+cmd+o",
         "command": "-workbench.action.gotoSymbol"

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -53,19 +53,39 @@
         "command": "-workbench.action.previousEditor"
     },
     {
-        "key": "ctrl+[",
-        "command": "workbench.action.navigateBack"
-    },
-    {
         "key": "ctrl+-",
         "command": "-workbench.action.navigateBack"
     },
     {
-        "key": "ctrl+]",
-        "command": "workbench.action.navigateForward"
-    },
-    {
         "key": "ctrl+shift+-",
         "command": "-workbench.action.navigateForward"
+    },
+    {
+        "key": "ctrl+]",
+        "command": "editor.action.indentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+]",
+        "command": "-editor.action.indentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "ctrl+[",
+        "command": "editor.action.outdentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+[",
+        "command": "-editor.action.outdentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+[",
+        "command": "workbench.action.navigateBack"
+    },
+    {
+        "key": "cmd+]",
+        "command": "workbench.action.navigateForward"
     }
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -78,4 +78,16 @@
         "key": "ctrl+[",
         "command": "workbench.action.navigateBack"
     },
+
+    // unbind copying lines up and down
+    {
+        "key": "shift+alt+up",
+        "command": "-editor.action.copyLinesUpAction",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "shift+alt+down",
+        "command": "-editor.action.copyLinesDownAction",
+        "when": "editorTextFocus && !editorReadonly"
+    },
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -1,5 +1,5 @@
 // Order of each section's key bindings:
-// 1. undo default bindings for action(s)
+// 1. undo default bindings for command(s)
 // 2. unbind target key(s)
 // 3. bind target key(s)
 [

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -3,6 +3,25 @@
 // 2. unbind target key(s)
 // 3. bind target key(s)
 [
+    // stop Vim from hijacking ctrl+d
+    {
+        "key": "ctrl+d",
+        "command": "-extension.vim_ctrl+d",
+        "when": "editorTextFocus && vim.active && !inDebugRepl"
+    },
+
+    // unbind copying lines up and down
+    {
+        "key": "shift+alt+up",
+        "command": "-editor.action.copyLinesUpAction",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "shift+alt+down",
+        "command": "-editor.action.copyLinesDownAction",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+
     // change gotoLine to cmd+l
     {
         "key": "ctrl+g",
@@ -16,13 +35,6 @@
     {
         "key": "cmd+l",
         "command": "workbench.action.gotoLine"
-    },
-
-    // stop Vim from hijacking ctrl+d
-    {
-        "key": "ctrl+d",
-        "command": "-extension.vim_ctrl+d",
-        "when": "editorTextFocus && vim.active && !inDebugRepl"
     },
 
     // change triggerSuggest to alt+space
@@ -79,18 +91,6 @@
     {
         "key": "ctrl+[",
         "command": "workbench.action.navigateBack"
-    },
-
-    // unbind copying lines up and down
-    {
-        "key": "shift+alt+up",
-        "command": "-editor.action.copyLinesUpAction",
-        "when": "editorTextFocus && !editorReadonly"
-    },
-    {
-        "key": "shift+alt+down",
-        "command": "-editor.action.copyLinesDownAction",
-        "when": "editorTextFocus && !editorReadonly"
     },
 
     // change goToReferences to cmd+r
@@ -190,11 +190,6 @@
         "command": "editor.action.rename",
         "when": "editorHasRenameProvider && editorTextFocus && !editorReadonly"
     },
-    {
-        "key": "cmd+p",
-        "command": "-workbench.action.quickOpenNavigateNextInFilePicker",
-        "when": "inFilesPicker && inQuickOpen"
-    },
 
     // change triggerParameterHints to cmd+p
     {
@@ -208,5 +203,37 @@
         "when": "editorHasSignatureHelpProvider && editorTextFocus"
     },
 
+    // change togglePanel to alt+p
+    {
+        "key": "cmd+j",
+        "command": "-workbench.action.togglePanel"
+    },
+    {
+        "key": "alt+p",
+        "command": "workbench.action.togglePanel"
+    },
 
+    // change jumpToBracket to alt+j
+    {
+        "key": "shift+cmd+\\",
+        "command": "-editor.action.jumpToBracket",
+        "when": "editorTextFocus"
+    },
+    {
+        "key": "alt+j",
+        "command": "editor.action.jumpToBracket",
+        "when": "editorTextFocus"
+    },
+
+    // change joinLines to cmd+j
+    {
+        "key": "ctrl+j",
+        "command": "-editor.action.joinLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+j",
+        "command": "editor.action.joinLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -117,14 +117,14 @@
 
     // change goToReferences to cmd+r
     {
-        "key": "cmd+r",
-        "command": "-workbench.action.reloadWindow",
-        "when": "isDevelopment"
-    },
-    {
         "key": "shift+f12",
         "command": "-editor.action.goToReferences",
         "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+    },
+    {
+        "key": "cmd+r",
+        "command": "-workbench.action.reloadWindow",
+        "when": "isDevelopment"
     },
     {
         "key": "cmd+r",
@@ -215,13 +215,13 @@
 
     // change triggerParameterHints to cmd+p
     {
-        "key": "cmd+p", // already unbound in quickOpen section
-        "command": "editor.action.triggerParameterHints",
+        "key": "shift+cmd+space",
+        "command": "-editor.action.triggerParameterHints",
         "when": "editorHasSignatureHelpProvider && editorTextFocus"
     },
     {
-        "key": "shift+cmd+space",
-        "command": "-editor.action.triggerParameterHints",
+        "key": "cmd+p", // already unbound in quickOpen section
+        "command": "editor.action.triggerParameterHints",
         "when": "editorHasSignatureHelpProvider && editorTextFocus"
     },
 

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -72,10 +72,10 @@
         "key": "ctrl+-",
         "command": "-workbench.action.navigateBack"
     },
-            {
-                "key": "ctrl+]",
-                "command": "workbench.action.navigateForward"
-            },
+    {
+        "key": "ctrl+]",
+        "command": "workbench.action.navigateForward"
+    },
     {
         "key": "ctrl+[",
         "command": "workbench.action.navigateBack"
@@ -108,5 +108,16 @@
         "key": "cmd+r",
         "command": "editor.action.goToReferences",
         "when": "editorHasReferenceProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+    },
+
+    // change go to implementation to cmd+i
+    {
+        "key": "cmd+f12",
+        "command": "-editor.action.goToImplementation",
+        "when": "editorHasImplementationProvider && editorTextFocus && !isInEmbeddedEditor"
+    },
+    {
+        "key": "cmd+i",
+        "command": "editor.action.goToImplementation"
     },
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -75,7 +75,29 @@
         "command": "workbench.action.previousEditor"
     },
 
-    // change navigation to ctrl+[ and ctrl+]
+    // change indentation to ctrl+[ and ctrl+]
+    {
+        "key": "cmd+]",
+        "command": "-editor.action.indentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "cmd+[",
+        "command": "-editor.action.outdentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "ctrl+]",
+        "command": "editor.action.indentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+    {
+        "key": "ctrl+[",
+        "command": "editor.action.outdentLines",
+        "when": "editorTextFocus && !editorReadonly"
+    },
+
+    // change navigation to cmd+[ and cmd+]
     {
         "key": "ctrl+shift+-",
         "command": "-workbench.action.navigateForward"
@@ -85,11 +107,11 @@
         "command": "-workbench.action.navigateBack"
     },
     {
-        "key": "ctrl+]",
+        "key": "cmd+]", // already unbound in change indentation section
         "command": "workbench.action.navigateForward"
     },
     {
-        "key": "ctrl+[",
+        "key": "cmd+[", // already unbound in change indentation section
         "command": "workbench.action.navigateBack"
     },
 
@@ -166,7 +188,7 @@
         "command": "-workbench.action.quickOpen"
     },
     {
-        "key": "shift+cmd+o", // already unbinded in gotoSymbol section
+        "key": "shift+cmd+o", // already unbound in gotoSymbol section
         "command": "workbench.action.quickOpen"
     },
 
@@ -193,7 +215,7 @@
 
     // change triggerParameterHints to cmd+p
     {
-        "key": "cmd+p", // already unbinded in quickOpen section
+        "key": "cmd+p", // already unbound in quickOpen section
         "command": "editor.action.triggerParameterHints",
         "when": "editorHasSignatureHelpProvider && editorTextFocus"
     },
@@ -236,4 +258,5 @@
         "command": "editor.action.joinLines",
         "when": "editorTextFocus && !editorReadonly"
     },
+
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -1,5 +1,11 @@
 // Place your key bindings in this file to override the defaults
+// order of each section key bindings: (1) existing keys to unbind (2) target keys to unbind (3) bind target keys
 [
+    // change goto line to cmd+l
+    {
+        "key": "ctrl+g",
+        "command": "-workbench.action.gotoLine"
+    },
     {
         "key": "cmd+l",
         "command": "-expandLineSelection",
@@ -9,24 +15,34 @@
         "key": "cmd+l",
         "command": "workbench.action.gotoLine"
     },
-    {
-        "key": "ctrl+g",
-        "command": "-workbench.action.gotoLine"
-    },
+
+    // stop Vim from hijacking ctrl+d
     {
         "key": "ctrl+d",
         "command": "-extension.vim_ctrl+d",
         "when": "editorTextFocus && vim.active && !inDebugRepl"
+    },
+
+    // change trigger suggest to alt+space
+    {
+        "key": "ctrl+space",
+        "command": "-editor.action.triggerSuggest",
+        "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly"
     },
     {
         "key": "alt+space",
         "command": "editor.action.triggerSuggest",
         "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly"
     },
+
+    // change switching editors to ctrl+tab and ctrl+shift+tab
     {
-        "key": "ctrl+space",
-        "command": "-editor.action.triggerSuggest",
-        "when": "editorHasCompletionItemProvider && textInputFocus && !editorReadonly"
+        "key": "alt+cmd+right",
+        "command": "-workbench.action.nextEditor"
+    },
+    {
+        "key": "alt+cmd+left",
+        "command": "-workbench.action.previousEditor"
     },
     {
         "key": "ctrl+tab",
@@ -41,51 +57,25 @@
         "command": "workbench.action.nextEditor"
     },
     {
-        "key": "alt+cmd+right",
-        "command": "-workbench.action.nextEditor"
-    },
-    {
         "key": "ctrl+shift+tab",
         "command": "workbench.action.previousEditor"
     },
-    {
-        "key": "alt+cmd+left",
-        "command": "-workbench.action.previousEditor"
-    },
-    {
-        "key": "ctrl+-",
-        "command": "-workbench.action.navigateBack"
-    },
+
+    // change navigating to ctrl+[ and ctrl+]
     {
         "key": "ctrl+shift+-",
         "command": "-workbench.action.navigateForward"
     },
     {
-        "key": "ctrl+]",
-        "command": "editor.action.indentLines",
-        "when": "editorTextFocus && !editorReadonly"
+        "key": "ctrl+-",
+        "command": "-workbench.action.navigateBack"
     },
-    {
-        "key": "cmd+]",
-        "command": "-editor.action.indentLines",
-        "when": "editorTextFocus && !editorReadonly"
-    },
+            {
+                "key": "ctrl+]",
+                "command": "workbench.action.navigateForward"
+            },
     {
         "key": "ctrl+[",
-        "command": "editor.action.outdentLines",
-        "when": "editorTextFocus && !editorReadonly"
-    },
-    {
-        "key": "cmd+[",
-        "command": "-editor.action.outdentLines",
-        "when": "editorTextFocus && !editorReadonly"
-    },
-    {
-        "key": "cmd+[",
         "command": "workbench.action.navigateBack"
     },
-    {
-        "key": "cmd+]",
-        "command": "workbench.action.navigateForward"
-    }
 ]

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -141,7 +141,7 @@
         "command": "-workbench.action.gotoSymbol"
     },
     {
-        "key": "ctrl+g", // already unbinded in gotoLine section
+        "key": "alt+g",
         "command": "workbench.action.gotoSymbol"
     },
 

--- a/Library/Application Support/Code/User/keybindings.json
+++ b/Library/Application Support/Code/User/keybindings.json
@@ -121,7 +121,7 @@
         "command": "references-view.findImplementations"
     },
 
-    // change showAllSymbols symbols to shift+cmd+s
+    // change showAllSymbols to shift+cmd+s
     {
         "key": "cmd+t",
         "command": "-workbench.action.showAllSymbols"


### PR DESCRIPTION
1. Make key bindings mnemonic (the key binding should contain the first letter of the command)
2. If not mnemonic, at least similar to key bindings of other common programs, e.g. Cmd+[ is also navigate back in Chrome
3. I used a few keybindings of alt+[letter] to force myself to use the alt key more and hopefully get faster at using it.
4. Organize key bindings into section, force an order of key bindings within each section, and document them
