### PR TITLE
set up a config file for ripgrep

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -14,7 +14,7 @@ set -xg EDITOR "nvim"
 set -xg LESS "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
 # don't store any history of commands executed in less
 set -xg LESSHISTFILE /dev/null
-# point ripgrep at config file
+# point ripgrep at its config file
 set -xg RIPGREP_CONFIG_PATH ~/.config/rg
 
 # visual settings

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -14,6 +14,8 @@ set -xg EDITOR "nvim"
 set -xg LESS "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
 # don't store any history of commands executed in less
 set -xg LESSHISTFILE /dev/null
+# point ripgrep at config file
+set -xg RIPGREP_CONFIG_PATH ~/.config/rg
 
 # visual settings
 set -g theme_nerd_fonts yes

--- a/.config/rg
+++ b/.config/rg
@@ -12,5 +12,5 @@
 # Search hidden files and directories
 --hidden
 
-# Never search in .git directory. This is necessary to include because of the --hidden flag above
+# Never search in the .git directory. This is necessary to include because of the --hidden flag above
 --glob=!.git

--- a/.config/rg
+++ b/.config/rg
@@ -1,0 +1,16 @@
+# Configuration file for ripgrep. Requires RIPGREP_CONFIG_PATH to point to this file.
+# Disable use of configuration files with --no-config
+
+# Searches case insensitively if the pattern is all lowercase. Search case sensitively otherwise.
+# Override with -s/--case-sensitive and -i/--ignore-case
+--smart-case
+
+# Only show a preview of lines that are longer than 200 bytes
+--max-columns=200
+--max-columns-preview
+
+# Search hidden files and directories
+--hidden
+
+# Never search in .git directory. This is necessary to include because of the --hidden flag above
+--glob=!.git

--- a/.config/rg
+++ b/.config/rg
@@ -1,16 +1,15 @@
 # Configuration file for ripgrep. Requires RIPGREP_CONFIG_PATH to point to this file.
-# Disable use of configuration files with --no-config
+# Disable use of configuration files with --no-config.
 
-# Searches case insensitively if the pattern is all lowercase. Search case sensitively otherwise.
-# Override with -s/--case-sensitive and -i/--ignore-case
---smart-case
+# Search case insensitively. Override with -s/--case-sensitive.
+--ignore-case
 
-# Only show a preview of lines that are longer than 200 bytes
+# Only show a preview of lines that are longer than 200 bytes.
 --max-columns=200
 --max-columns-preview
 
-# Search hidden files and directories
+# Search hidden files and directories.
 --hidden
 
-# Never search in the .git directory. This is necessary to include because of the --hidden flag above
+# Never search in the .git directory. This is necessary to include because of --hidden.
 --glob=!.git


### PR DESCRIPTION
Default `rg` to search case insensitively, not display super long lines, and to search hidden files but not .git.