### PR TITLE
Configure less using lesskey file

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -15,9 +15,6 @@ export HISTTIMEFORMAT='%F %T '
 shopt -s histverify # don't immediately execute commands from history but copy them onto command line
 shopt -s histappend # append to bash history instead of overwriting
 
-export LESS="--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
-export LESSHISTFILE='/dev/null'
-
 export FZF_DEFAULT_OPTS="--cycle --layout=reverse --border --height=90% --preview-window=wrap --marker='*'"
 
 test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shell_integration.bash"

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -13,10 +13,6 @@ set -q INFOPATH; or set INFOPATH ''
 set -gx INFOPATH /opt/homebrew/share/info $INFOPATH
 
 set -x EDITOR nvim
-# set some sensible default options to always pass into invocations of less
-set -x LESS "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
-# don't store any history of commands executed in less
-set -x LESSHISTFILE /dev/null
 # point ripgrep at its config file
 set -x RIPGREP_CONFIG_PATH ~/.config/ripgrep
 

--- a/.config/fish/fish_plugins
+++ b/.config/fish/fish_plugins
@@ -2,7 +2,6 @@ ilancosman/tide@v5
 jorgebucaran/bax.fish
 jorgebucaran/fisher
 oh-my-fish/plugin-wifi-password
-patrickf1/colored_man_pages.fish
 patrickf1/fzf.fish
 jorgebucaran/fishtape
 ilancosman/clownfish

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -6,6 +6,6 @@ t  toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS = --mouse --wheel-lines=5 --quit-on-intr --ignore-case --RAW-CONTROL-CHARS --tabs=4 --window=-4--color=db$ --color=ug$ --color=sky$ --prompt=slines=%lt-%lb / %L$
+LESS = --mouse --wheel-lines=5 --quit-on-intr --ignore-case --RAW-CONTROL-CHARS --tabs=4 --window=-4--color=db$ --color=ug$ --color=sky$ --prompt=sInput= %f, Lines= %lt-%lb / %L$
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -4,6 +4,6 @@ t toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr
+LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --color=db
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -4,8 +4,6 @@ t toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS += --quit-on-intr
-LESS += "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
+LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr
 # don't store any history of commands executed in less
-LESSHISTFILE += /dev/null
-
+LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -7,5 +7,5 @@ t toggle-option --ignore-case\n
 LESS += --quit-on-intr
 LESS += "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
 # don't store any history of commands executed in less
-LESSHISTFILE /dev/null
+LESSHISTFILE += /dev/null
 

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -1,0 +1,7 @@
+# less automatically loads ~/.config/lesskey to configure itself, no need to set environment variable
+#command
+t toggle-option --ignore-case\n
+
+#env
+LESS += --quit-on-intr
+

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -5,7 +5,7 @@ t  toggle-option --ignore-case\n
 \e clear-search
 
 #env
-# set some sensible default options to always pass into invocations of less
+# $ is necessary to delinate some options
 LESS = --mouse --wheel-lines=5 --quit-on-intr --ignore-case --RAW-CONTROL-CHARS --tabs=4 --window=-4--color=db$ --color=ug$ --color=sky$ --prompt=sInput= %f, Lines= %lt-%lb / %L$
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -4,6 +4,6 @@ t toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --use-color --color=db$ --color=ug$ --color=Py$ --color=sy$
+LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --color=db$ --color=ug$ --color=sky$
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -6,6 +6,6 @@ t  toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --color=db$ --color=ug$ --color=sky$
+LESS = --mouse --wheel-lines=5 --quit-on-intr --ignore-case --RAW-CONTROL-CHARS --tabs=4 --window=-4--color=db$ --color=ug$ --color=sky$ --prompt=slines=%lt-%lb / %L$
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -4,6 +4,6 @@ t toggle-option --ignore-case\n
 
 #env
 # set some sensible default options to always pass into invocations of less
-LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --color=db
+LESS = --ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4 --quit-on-intr --use-color --color=db$ --color=ug$ --color=Py$ --color=sy$
 # don't store any history of commands executed in less
 LESSHISTFILE = /dev/null

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -1,6 +1,8 @@
 # less automatically loads ~/.config/lesskey to configure itself, no need to set environment variable
 #command
-t toggle-option --ignore-case\n
+t  toggle-option --ignore-case\n
+# clear search highlighting with escape escape
+\e clear-search
 
 #env
 # set some sensible default options to always pass into invocations of less

--- a/.config/lesskey
+++ b/.config/lesskey
@@ -3,5 +3,9 @@
 t toggle-option --ignore-case\n
 
 #env
+# set some sensible default options to always pass into invocations of less
 LESS += --quit-on-intr
+LESS += "--ignore-case --LONG-PROMPT --RAW-CONTROL-CHARS --tabs=4 --window=-4"
+# don't store any history of commands executed in less
+LESSHISTFILE /dev/null
 


### PR DESCRIPTION
The main change is migrating less configuration from the LESS environment variable to the lesskey source file
- no more maintaining and duplicating the LESS environment variable across multiple shells
- less automatically picks up the new configuration without re-sourcing shell config files
- less' configuration consolidated in one place, versus being in random section of config files (and a fish plugin)

Additionally, took advantage of lesskey's convenient configuration functionality
- create mnemonic keybinding t for toggling search sensitivity modes
- create binding escape-escape to toggle search highlighting
- use a longer prompt that shows input file and the lines
- emulate https://github.com/PatrickF1/colored_man_pages.fish colors using --color
- enable quitting faster with Ctrl-C
- facilitate faster scrolling with mouse wheel

Investing in less configuration makes sense since it is the basis of reading manual pages and git patches.