### PR TITLE
Move env vars to ~/.env shared by fish and bash

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -12,6 +12,7 @@ if [ -f "$HOME/.env" ]; then
 fi
 
 # Bash-specific machine-local config (gitignored): NVM init, derived URLs, etc.
+# Must be sourced after ~/.env, since it references vars defined there.
 [ -f "$HOME/secrets.bash" ] && . "$HOME/secrets.bash"
 
 source ~/.config/bash/aliases.bash

--- a/.bashrc
+++ b/.bashrc
@@ -3,6 +3,17 @@
 
 export PATH="$HOME/.local/bin":$PATH
 
+# Load cross-shell env vars from ~/.env (KEY=value, gitignored).
+# `set -a` auto-exports every assignment in the sourced file.
+if [ -f "$HOME/.env" ]; then
+    set -a
+    . "$HOME/.env"
+    set +a
+fi
+
+# Bash-specific machine-local config (gitignored): NVM init, derived URLs, etc.
+[ -f "$HOME/secrets.bash" ] && . "$HOME/secrets.bash"
+
 source ~/.config/bash/aliases.bash
 source ~/.config/bash/functions.bash
 source ~/.config/bash/git-completion.bash

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -14,7 +14,11 @@ set -gx INFOPATH /opt/homebrew/share/info $INFOPATH
 # point ripgrep at its config file
 set -x RIPGREP_CONFIG_PATH ~/.config/ripgrep
 
-source ~/secrets.fish
+# Load cross-shell env vars from ~/.env (KEY=value, gitignored).
+load_env ~/.env
+
+# Fish-specific machine-local config (gitignored): fish_add_path, derived URLs, etc.
+test -f ~/secrets.fish; and source ~/secrets.fish
 
 ###################################
 # Interactive mode configurations #

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -18,6 +18,7 @@ set -x RIPGREP_CONFIG_PATH ~/.config/ripgrep
 load_env ~/.env
 
 # Fish-specific machine-local config (gitignored): fish_add_path, derived URLs, etc.
+# Must be sourced after ~/.env, since it references vars defined there.
 test -f ~/secrets.fish; and source ~/secrets.fish
 
 ###################################

--- a/.config/fish/fish_plugins
+++ b/.config/fish/fish_plugins
@@ -1,5 +1,4 @@
 ilancosman/tide@v6
-jorgebucaran/replay.fish
 jorgebucaran/fisher
 oh-my-fish/plugin-wifi-password
 patrickf1/fzf.fish

--- a/.config/fish/functions/load_env.fish
+++ b/.config/fish/functions/load_env.fish
@@ -10,9 +10,14 @@ function load_env --description 'Load KEY=value lines from a .env-style file int
         test (count $parts) -eq 2; or continue
         set -l key (string trim -- $parts[1])
         set -l val (string trim -- $parts[2])
-        # strip optional surrounding single or double quotes
+        # Strip optional surrounding single or double quotes so that the same
+        # ~/.env file behaves identically when bash sources it: bash parses
+        # KEY="value" as shell code and naturally drops the quotes, so fish
+        # must do the same to avoid setting the var to a literal `"value"`.
         set val (string replace -r '^"(.*)"$' '$1' -- $val)
         set val (string replace -r "^'(.*)'\$" '$1' -- $val)
+        # -g persists past this function's scope; -x exports to child processes.
+        # Together this matches what bash's `set -a; .` produces for the same file.
         set -gx $key $val
     end < $file
 end

--- a/.config/fish/functions/load_env.fish
+++ b/.config/fish/functions/load_env.fish
@@ -17,7 +17,6 @@ function load_env --description 'Load KEY=value lines from a .env-style file int
         set val (string replace -r '^"(.*)"$' '$1' -- $val)
         set val (string replace -r "^'(.*)'\$" '$1' -- $val)
         # -g persists past this function's scope; -x exports to child processes.
-        # Together this matches what bash's `set -a; .` produces for the same file.
         set -gx $key $val
-    end < $file
+    end <$file
 end

--- a/.config/fish/functions/load_env.fish
+++ b/.config/fish/functions/load_env.fish
@@ -1,0 +1,18 @@
+function load_env --description 'Load KEY=value lines from a .env-style file into fish global env'
+    set -l file $argv[1]
+    test -f "$file"; or return 0
+
+    while read -l line
+        # skip blank lines and comments
+        string match -qr '^\s*(#|$)' -- $line; and continue
+        # split on first '='
+        set -l parts (string split -m 1 = -- $line)
+        test (count $parts) -eq 2; or continue
+        set -l key (string trim -- $parts[1])
+        set -l val (string trim -- $parts[2])
+        # strip optional surrounding single or double quotes
+        set val (string replace -r '^"(.*)"$' '$1' -- $val)
+        set val (string replace -r "^'(.*)'\$" '$1' -- $val)
+        set -gx $key $val
+    end < $file
+end

--- a/.github/README.md
+++ b/.github/README.md
@@ -48,17 +48,14 @@ When adding new files, remember that untracked files are not shown by git status
 
 This repo is public, so anything sensitive or machine-specific lives outside of it in three gitignored files:
 
-| File              | Purpose                                                                                  | Loaded by                  |
-| ----------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
-| `~/.env`          | Cross-shell env vars in plain `KEY=value` format (one per line, no `export` or quotes).  | `.bashrc`, `config.fish`   |
-| `~/secrets.bash`  | Bash-only setup that can't be expressed as `KEY=value` (NVM init, derived URLs, etc.).   | `.bashrc`                  |
-| `~/secrets.fish`  | Fish-only setup (`fish_add_path`, derived URLs, etc.).                                   | `config.fish`              |
+| File             | Purpose                                                                                 | Loaded by                |
+| ---------------- | --------------------------------------------------------------------------------------- | ------------------------ |
+| `~/.env`         | Cross-shell env vars in plain `KEY=value` format (one per line, no `export` or quotes). | `.bashrc`, `config.fish` |
+| `~/secrets.bash` | Bash-only setup that can't be expressed as `KEY=value` (NVM init, derived URLs, etc.).  | `.bashrc`                |
+| `~/secrets.fish` | Fish-only setup (`fish_add_path`, derived URLs, etc.).                                  | `config.fish`            |
 
-The point of `~/.env` is to have a single source of truth for env vars across both shells. `.bashrc` reads it with the POSIX `set -a; . ~/.env; set +a` trick (which auto-exports every assignment). `config.fish` reads it via the `load_env` autoloaded function, which parses `KEY=value` lines and runs `set -gx` on each.
-
-`~/secrets.bash` and `~/secrets.fish` are sourced after `~/.env`, so they can reference any var defined there. Keep them thin — anything that's a plain `KEY=value` belongs in `~/.env`. Only put things in the shell-specific files when they genuinely need shell-specific syntax (`fish_add_path`, NVM init, parameter expansion for URL-encoding, etc.).
-
-To add or rotate a secret: edit `~/.env` once, open a new shell, and both bash and fish pick it up.
+`~/.env` servces as single source of truth for env vars across both shells; `.bashrc` and `config.fish` load it.
+Anything that's a plain `KEY=value` belongs in `~/.env`; only put things in the shell-specific files when they need shell-specific syntax.
 
 # Specific instructions for updating non-automated apps
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -54,8 +54,7 @@ This repo is public, so anything sensitive or machine-specific lives outside of 
 | `~/secrets.bash` | Bash-only setup that can't be expressed as `KEY=value` (NVM init, derived URLs, etc.).  | `.bashrc`                |
 | `~/secrets.fish` | Fish-only setup (`fish_add_path`, derived URLs, etc.).                                  | `config.fish`            |
 
-`~/.env` servces as single source of truth for env vars across both shells; `.bashrc` and `config.fish` load it.
-Anything that's a plain `KEY=value` belongs in `~/.env`; only put things in the shell-specific files when they need shell-specific syntax.
+`~/.env` serves as single source of truth for env vars across both shells. Anything that's a plain `KEY=value` belongs in `~/.env`; only put things in the shell-specific files when they need shell-specific syntax.
 
 # Specific instructions for updating non-automated apps
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -46,7 +46,7 @@ When adding new files, remember that untracked files are not shown by git status
 
 ## Secrets and machine-local config
 
-This repo is public, so anything sensitive or machine-specific lives outside of it in three gitignored files:
+Any sensitive or machine-specific config lives outside the repo in three gitignored files:
 
 | File             | Purpose                                                                                 | Loaded by                |
 | ---------------- | --------------------------------------------------------------------------------------- | ------------------------ |
@@ -54,7 +54,8 @@ This repo is public, so anything sensitive or machine-specific lives outside of 
 | `~/secrets.bash` | Bash-only setup that can't be expressed as `KEY=value` (NVM init, derived URLs, etc.).  | `.bashrc`                |
 | `~/secrets.fish` | Fish-only setup (`fish_add_path`, derived URLs, etc.).                                  | `config.fish`            |
 
-`~/.env` serves as single source of truth for env vars across both shells. Anything that's a plain `KEY=value` belongs in `~/.env`; only put things in the shell-specific files when they need shell-specific syntax.
+`~/.env` serves as single source of truth for env vars across both shells.
+Anything that's a plain `KEY=value` belongs in `~/.env`; only put things in the shell-specific files when they need shell-specific syntax.
 
 # Specific instructions for updating non-automated apps
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -44,6 +44,22 @@ Be very careful about not running `dot add -A` on the home directory. To avoid a
 
 When adding new files, remember that untracked files are not shown by git status.
 
+## Secrets and machine-local config
+
+This repo is public, so anything sensitive or machine-specific lives outside of it in three gitignored files:
+
+| File              | Purpose                                                                                  | Loaded by                  |
+| ----------------- | ---------------------------------------------------------------------------------------- | -------------------------- |
+| `~/.env`          | Cross-shell env vars in plain `KEY=value` format (one per line, no `export` or quotes).  | `.bashrc`, `config.fish`   |
+| `~/secrets.bash`  | Bash-only setup that can't be expressed as `KEY=value` (NVM init, derived URLs, etc.).   | `.bashrc`                  |
+| `~/secrets.fish`  | Fish-only setup (`fish_add_path`, derived URLs, etc.).                                   | `config.fish`              |
+
+The point of `~/.env` is to have a single source of truth for env vars across both shells. `.bashrc` reads it with the POSIX `set -a; . ~/.env; set +a` trick (which auto-exports every assignment). `config.fish` reads it via the `load_env` autoloaded function, which parses `KEY=value` lines and runs `set -gx` on each.
+
+`~/secrets.bash` and `~/secrets.fish` are sourced after `~/.env`, so they can reference any var defined there. Keep them thin — anything that's a plain `KEY=value` belongs in `~/.env`. Only put things in the shell-specific files when they genuinely need shell-specific syntax (`fish_add_path`, NVM init, parameter expansion for URL-encoding, etc.).
+
+To add or rotate a secret: edit `~/.env` once, open a new shell, and both bash and fish pick it up.
+
 # Specific instructions for updating non-automated apps
 
 ## VSCode settings

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ Projects
 .python_history
 .viminfo
 
-# Ignore secrets
+# Ignore secrets and machine-local config
 .config/gh/hosts.yml
+.env
 secrets.bash
 secrets.fish


### PR DESCRIPTION
## Summary

- Cross-shell `KEY=value` env vars now live in a single gitignored `~/.env`, eliminating the prior duplication where every var had to be declared twice and with different syntaxes (once with `export` in `~/secrets.bash`, again with `set -gx` in `~/secrets.fish`).
- `.bashrc` reads `~/.env` via `set -a; . ~/.env; set +a`. `config.fish` reads it via a new `load_env` autoloaded function.
- `~/secrets.bash` and `~/secrets.fish` remain (gitignored) for shell-specific machine-local setup that can't be expressed as `KEY=value` (NVM init, `fish_add_path`, derived URLs that need bash parameter expansion or fish `string replace` for URL-encoding).
- Drops the `replay.fish` plugin — only used to bridge bash → fish for shared exports, no longer needed.
- Documents the layout in `.github/README.md`.

## Test plan

- [x] Verified bash end-to-end: clean env, source `~/.env` then `~/secrets.bash`, all expected vars present.
- [x] Verified fish end-to-end: clean env, `load_env ~/.env` then source `~/secrets.fish`, all expected vars present.
- [x] Diffed fish env between old config and new config — byte-identical after restoring `NVM_DIR` in `secrets.fish`.
- [x] Diffed `$fish_user_paths` — identical.
- [x] Confirmed no work-identifying strings or token prefixes in committed files.
- [x] Claude Code tested `load_env`