### PR TITLE
Automate bootstrap

### DIFF
--- a/.asdfrc
+++ b/.asdfrc
@@ -1,2 +1,0 @@
-legacy_version_file = yes
-use_release_candidates = no

--- a/.dotfiles_meta/bootstrap.sh
+++ b/.dotfiles_meta/bootstrap.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# One-command bootstrap for a fresh macOS machine.
+#
+# This is the only step that cannot be written in fish, since fish itself is
+# installed by Homebrew further down. Everything after the Homebrew bundle is
+# delegated to the fish scripts in this directory.
+#
+# Safe to re-run: every step is guarded and idempotent.
+#
+# Usage (fresh machine, repo not yet cloned):
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/patrickf1/dotfiles/main/.dotfiles_meta/bootstrap.sh)"
+#
+# Usage (repo already cloned):
+#   bash ~/Code/dotfiles/.dotfiles_meta/bootstrap.sh
+
+set -euo pipefail
+
+REPO_URL="https://github.com/patrickf1/dotfiles"
+DOTFILES_DIR="$HOME/Code/dotfiles"
+
+log() { printf '\n\033[1;34m==>\033[0m %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# 1. Xcode Command Line Tools (provides git, compilers Homebrew needs)
+# ---------------------------------------------------------------------------
+if ! xcode-select -p >/dev/null 2>&1; then
+    log "Installing Xcode Command Line Tools"
+    xcode-select --install
+    echo "Waiting for the Command Line Tools install to finish..."
+    until xcode-select -p >/dev/null 2>&1; do
+        sleep 5
+    done
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Homebrew
+# ---------------------------------------------------------------------------
+if ! command -v brew >/dev/null 2>&1; then
+    log "Installing Homebrew"
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
+
+# Make brew available for the remainder of this script (Apple Silicon prefix).
+if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Clone the dotfiles repo into its expected home
+# ---------------------------------------------------------------------------
+if [ ! -d "$DOTFILES_DIR/.git" ]; then
+    log "Cloning dotfiles into $DOTFILES_DIR"
+    mkdir -p "$DOTFILES_DIR"
+    git clone "$REPO_URL" "$DOTFILES_DIR"
+fi
+
+# Wrapper that runs git against the home directory, mirroring the `dot` fish function.
+dot() { git --git-dir="$DOTFILES_DIR/.git" --work-tree="$HOME" "$@"; }
+
+# ---------------------------------------------------------------------------
+# 4. Check the tracked files out into $HOME and quiet untracked-file noise
+# ---------------------------------------------------------------------------
+log "Checking out dotfiles into \$HOME"
+dot reset --hard
+
+dot config --local status.showUntrackedFiles no
+
+# ---------------------------------------------------------------------------
+# 5. Install everything in the Brewfile
+# ---------------------------------------------------------------------------
+log "Installing Homebrew bundle"
+brew bundle install --file="$DOTFILES_DIR/.dotfiles_meta/Brewfile"
+
+# ---------------------------------------------------------------------------
+# 6. Hand off to the fish installers
+# ---------------------------------------------------------------------------
+log "Installing shell utilities"
+fish "$DOTFILES_DIR/.dotfiles_meta/install_shell_utilities.fish"
+
+log "Configuring macOS"
+fish "$DOTFILES_DIR/.dotfiles_meta/configure_macos.fish"
+
+log "Done! Open a new fish session to pick up all changes."

--- a/.dotfiles_meta/bootstrap.sh
+++ b/.dotfiles_meta/bootstrap.sh
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
-#
 # One-command bootstrap for a fresh macOS machine.
-#
-# This is the only step that cannot be written in fish, since fish itself is
-# installed by Homebrew further down. Everything after the Homebrew bundle is
-# delegated to the fish scripts in this directory.
-#
-# Safe to re-run: every step is guarded and idempotent.
-#
-# Usage (fresh machine, repo not yet cloned):
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/patrickf1/dotfiles/main/.dotfiles_meta/bootstrap.sh)"
-#
-# Usage (repo already cloned):
-#   bash ~/Code/dotfiles/.dotfiles_meta/bootstrap.sh
 
 set -euo pipefail
 
@@ -21,9 +8,6 @@ DOTFILES_DIR="$HOME/Code/dotfiles"
 
 log() { printf '\n\033[1;34m==>\033[0m %s\n' "$1"; }
 
-# ---------------------------------------------------------------------------
-# 1. Xcode Command Line Tools (provides git, compilers Homebrew needs)
-# ---------------------------------------------------------------------------
 if ! xcode-select -p >/dev/null 2>&1; then
     log "Installing Xcode Command Line Tools"
     xcode-select --install
@@ -33,22 +17,16 @@ if ! xcode-select -p >/dev/null 2>&1; then
     done
 fi
 
-# ---------------------------------------------------------------------------
-# 2. Homebrew
-# ---------------------------------------------------------------------------
 if ! command -v brew >/dev/null 2>&1; then
     log "Installing Homebrew"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
-# Make brew available for the remainder of this script (Apple Silicon prefix).
+# Make brew available for the remainder of this script
 if [ -x /opt/homebrew/bin/brew ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-# ---------------------------------------------------------------------------
-# 3. Clone the dotfiles repo into its expected home
-# ---------------------------------------------------------------------------
 if [ ! -d "$DOTFILES_DIR/.git" ]; then
     log "Cloning dotfiles into $DOTFILES_DIR"
     mkdir -p "$DOTFILES_DIR"
@@ -58,23 +36,15 @@ fi
 # Wrapper that runs git against the home directory, mirroring the `dot` fish function.
 dot() { git --git-dir="$DOTFILES_DIR/.git" --work-tree="$HOME" "$@"; }
 
-# ---------------------------------------------------------------------------
-# 4. Check the tracked files out into $HOME and quiet untracked-file noise
-# ---------------------------------------------------------------------------
+
 log "Checking out dotfiles into \$HOME"
 dot reset --hard
 
 dot config --local status.showUntrackedFiles no
 
-# ---------------------------------------------------------------------------
-# 5. Install everything in the Brewfile
-# ---------------------------------------------------------------------------
 log "Installing Homebrew bundle"
 brew bundle install --file="$DOTFILES_DIR/.dotfiles_meta/Brewfile"
 
-# ---------------------------------------------------------------------------
-# 6. Hand off to the fish installers
-# ---------------------------------------------------------------------------
 log "Installing shell utilities"
 fish "$DOTFILES_DIR/.dotfiles_meta/install_shell_utilities.fish"
 

--- a/.dotfiles_meta/configure_macos.fish
+++ b/.dotfiles_meta/configure_macos.fish
@@ -1,6 +1,5 @@
 #!/usr/bin/env fish
 
-echo "Configuring macOS and built-in apps"
 # Close any open System Settings panes to prevent them from overriding
 # the settings being configured
 osascript -e 'tell application "System Settings" to quit'
@@ -169,4 +168,4 @@ for app in Finder Dock cfprefsd SystemUIServer Alfred Postico
     killall -q $app
 end
 
-echo "Done. You may need to restart currently running applications for new settings to kick in."
+echo "Some changes may need a new login session or app restart to take effect"

--- a/.dotfiles_meta/install_shell_utilities.fish
+++ b/.dotfiles_meta/install_shell_utilities.fish
@@ -11,6 +11,8 @@ set -l vim_plug_path ~/.local/share/nvim/site/autoload/plug.vim
 if test ! -e "$vim_plug_path"
     echo "Installing vim-plug for neovim"
     curl --create-dirs --location --output "$vim_plug_path" https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+    echo "Installing neovim plugins"
+    nvim --headless +PlugInstall +qall
 end
 
 set -l bash_git_completion_path ~/.config/bash/git-completion.bash
@@ -39,5 +41,5 @@ if test -e ~/Library/Fonts/JetBrainsMono-SemiBold.ttf
     rm -f ~/Library/Fonts/JetBrainsMono{,NL}-{SemiBold, SemiBoldItalic}.ttf
 end
 
-# make it obvious where to put secrets
-touch ~/secrets.fish
+# make it obvious where to put machine-local config and secrets
+touch ~/.env ~/secrets.bash ~/secrets.fish

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,10 @@
 # dotfiles
 
-My configuration and bootstrap files for `bash`, `fish`, `git`, `Visual Studio Code`, and even `brew`, `macOS settings`, and the settings for some applications. Includes scripts to automate installation. These are my bespoke dotfiles and workflow and therefore are likely ill-suited for everyone else. That said, I did my best to make my dotfiles as lightweight and sensible as possible so they may be worth forking as a starting point for your dotfiles.
+## About
+
+My configuration and bootstrap files for `bash`, `fish`, `git`, `Visual Studio Code`, and even `brew`, `macOS settings`, and the settings for some applications. Includes scripts to automate installation as much as possible. These are my bespoke dotfiles and workflow and therefore are likely ill-suited for everyone else. That said, I did my best to make my dotfiles as lightweight and sensible as possible so they may be worth forking as a starting point for your dotfiles.
+
+Unlike most other dotfiles repos that use symlinks or `rsync` to manage your dotfiles, we will use git and only git. See this very excellent [Atlassian article](https://www.atlassian.com/git/tutorials/dotfiles) and [DistroTube tutorial](https://www.youtube.com/watch?v=tBoLDpTWVOM) for a primer, though this setup is a bit different. The basic idea is that this repository's directory structure mirrors `$HOME`'s directory structure when all the dotfiles exist in their proper place. By setting up this repository in this way, we will be able to set our git working directory to the home directory and checkout dotfiles directly into the directories they should go.
 
 ## Assumptions
 
@@ -11,17 +15,11 @@ My configuration and bootstrap files for `bash`, `fish`, `git`, `Visual Studio C
 
 ## Installing
 
-Unlike most other dotfiles repos that use symlinks or `rsync` to manage your dotfiles, we will use git and only git. See this very excellent [Atlassian article](https://www.atlassian.com/git/tutorials/dotfiles) and [DistroTube tutorial](https://www.youtube.com/watch?v=tBoLDpTWVOM) for a primer, though this setup is a bit different. The basic idea is that this repository's directory structure mirrors `$HOME`'s directory structure when all the dotfiles exist in their proper place. By setting up this repository in this way, we will be able to set our git working directory to the home directory and checkout dotfiles directly into the directories they should go.
-
-On a fresh machine, run the one-command bootstrap. It installs the Xcode Command Line Tools and Homebrew (neither of which is present on a clean macOS install), clones this repo, checks the dotfiles out into `$HOME`, installs the Brewfile, and runs the two fish setup scripts:
+On a fresh machine, run the bootstrap script
 
 ```sh
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/patrickf1/dotfiles/main/.dotfiles_meta/bootstrap.sh)"
-```
-
-The script ([`.dotfiles_meta/bootstrap.sh`](../.dotfiles_meta/bootstrap.sh)) is idempotent, so it's safe to re-run after pulling new changes. It is commented step by step if you want to see exactly what it does. If the repo is already cloned, you can run it directly instead of via `curl`:
-
-```sh
+# or if the repo is already cloned, run it directly
 bash ~/Code/dotfiles/.dotfiles_meta/bootstrap.sh
 ```
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -13,19 +13,37 @@ My configuration and bootstrap files for `bash`, `fish`, `git`, `Visual Studio C
 
 Unlike most other dotfiles repos that use symlinks or `rsync` to manage your dotfiles, we will use git and only git. See this very excellent [Atlassian article](https://www.atlassian.com/git/tutorials/dotfiles) and [DistroTube tutorial](https://www.youtube.com/watch?v=tBoLDpTWVOM) for a primer, though this setup is a bit different. The basic idea is that this repository's directory structure mirrors `$HOME`'s directory structure when all the dotfiles exist in their proper place. By setting up this repository in this way, we will be able to set our git working directory to the home directory and checkout dotfiles directly into the directories they should go.
 
+On a fresh machine, run the one-command bootstrap. It installs the Xcode Command Line Tools and Homebrew (neither of which is present on a clean macOS install), clones this repo, checks the dotfiles out into `$HOME`, installs the Brewfile, and runs the two fish setup scripts:
+
 ```sh
-# clone the repo into the expected place (~/Code/dotfiles)
-cd # start installation steps from home directory
-mkdir -p Code/dotfiles
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/patrickf1/dotfiles/main/.dotfiles_meta/bootstrap.sh)"
+```
+
+The script ([`.dotfiles_meta/bootstrap.sh`](../.dotfiles_meta/bootstrap.sh)) is idempotent, so it's safe to re-run after pulling new changes. If the repo is already cloned, you can run it directly instead of via `curl`:
+
+```sh
+bash ~/Code/dotfiles/.dotfiles_meta/bootstrap.sh
+```
+
+For reference, the bootstrap performs these steps:
+
+```sh
+# 1. Xcode Command Line Tools (provides git)
+xcode-select --install
+
+# 2. Homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# 3. clone the repo into the expected place (~/Code/dotfiles)
 git clone https://github.com/patrickf1/dotfiles ~/Code/dotfiles
 
-# checkout all the files into our home directory by making it the git working directory
+# 4. checkout all the files into our home directory by making it the git working directory
 git --git-dir=Code/dotfiles/.git --work-tree=. reset --hard
 
-# hide untracked files so the output of git status is not overwhelming
+# 5. hide untracked files so the output of git status is not overwhelming
 git --git-dir=Code/dotfiles/.git config --local status.showUntrackedFiles no
 
-# run all the install scripts, which are located in .dotfiles_meta
+# 6. run all the install scripts, which are located in .dotfiles_meta
 cd Code/dotfiles/.dotfiles_meta
 brew bundle install
 fish install_shell_utilities.fish

--- a/.github/README.md
+++ b/.github/README.md
@@ -19,35 +19,10 @@ On a fresh machine, run the one-command bootstrap. It installs the Xcode Command
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/patrickf1/dotfiles/main/.dotfiles_meta/bootstrap.sh)"
 ```
 
-The script ([`.dotfiles_meta/bootstrap.sh`](../.dotfiles_meta/bootstrap.sh)) is idempotent, so it's safe to re-run after pulling new changes. If the repo is already cloned, you can run it directly instead of via `curl`:
+The script ([`.dotfiles_meta/bootstrap.sh`](../.dotfiles_meta/bootstrap.sh)) is idempotent, so it's safe to re-run after pulling new changes. It is commented step by step if you want to see exactly what it does. If the repo is already cloned, you can run it directly instead of via `curl`:
 
 ```sh
 bash ~/Code/dotfiles/.dotfiles_meta/bootstrap.sh
-```
-
-For reference, the bootstrap performs these steps:
-
-```sh
-# 1. Xcode Command Line Tools (provides git)
-xcode-select --install
-
-# 2. Homebrew
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-# 3. clone the repo into the expected place (~/Code/dotfiles)
-git clone https://github.com/patrickf1/dotfiles ~/Code/dotfiles
-
-# 4. checkout all the files into our home directory by making it the git working directory
-git --git-dir=Code/dotfiles/.git --work-tree=. reset --hard
-
-# 5. hide untracked files so the output of git status is not overwhelming
-git --git-dir=Code/dotfiles/.git config --local status.showUntrackedFiles no
-
-# 6. run all the install scripts, which are located in .dotfiles_meta
-cd Code/dotfiles/.dotfiles_meta
-brew bundle install
-fish install_shell_utilities.fish
-fish configure_macos.fish
 ```
 
 ## Workflow for updating dotfiles


### PR DESCRIPTION
## Automate and tidy the dotfiles bootstrap

### Summary

Closes the gaps in the bootstrap process so a fresh macOS machine can be set up with a single command, and tidies up the supporting scripts and docs. Previously the README's install steps assumed `git` and Homebrew were already present--neither exists on a clean install--and a couple of setup steps were either manual or incomplete.

### Changes

**One-command bootstrap (`.dotfiles_meta/bootstrap.sh`)**
- New script that takes a clean machine end to end: installs the Xcode Command Line Tools and Homebrew, clones the repo, checks the dotfiles out into `$HOME`, sets `status.showUntrackedFiles no`, installs the Brewfile, and runs the two fish setup scripts.
- This is the one piece that can't be written in fish, since fish itself is installed by Homebrew partway through.
- Every step is guarded, so it's safe to re-run after pulling new changes. Can be run via `curl` on a fresh machine or directly once the repo is cloned.

**Finish the neovim and secrets setup (`install_shell_utilities.fish`)**
- Run `:PlugInstall` after fetching vim-plug, so the plugins declared in `init.vim` actually get installed (previously vim-plug was downloaded but never invoked).
- Scaffold all three machine-local files (`~/.env`, `~/secrets.bash`, `~/secrets.fish`), not just `secrets.fish`, matching what the README documents.

**Consistent install logging**
- `bootstrap.sh` is now the single narrator: it prints a `==>` header before each phase and one final `Done!`. The fish scripts just emit their own plain progress lines, with no logging helper duplicated across scripts. Removes the previous double "Done" and the unannounced shell-utilities phase.

**Cleanup**
- Remove the orphaned `.asdfrc` (asdf isn't installed or referenced anywhere; Node version management goes through NVM).
- Trim the duplicated step-by-step block from the README now that it's a verbatim copy of `bootstrap.sh`; keep the conceptual explanation of the git-mirror approach.
